### PR TITLE
Past Meetings

### DIFF
--- a/lib/ohio_elixir/events.ex
+++ b/lib/ohio_elixir/events.ex
@@ -19,8 +19,22 @@ defmodule OhioElixir.Events do
 
   """
   def list_meetings do
-    from(m in Meeting, order_by: [desc: m.date])
-    |> Repo.all()
+    from(m in Meeting, order_by: [desc: m.date]) |> Repo.all()
+  end
+
+  @doc """
+  Returns the list of previous meetings.
+
+  ## Examples
+
+      iex> list_past_meetings()
+      [%Meeting{}, ...]
+
+  """
+  def list_past_meetings do
+    today = DateTime.utc_now()
+
+    from(m in Meeting, order_by: [desc: m.date], where: m.date <= ^today) |> Repo.all()
   end
 
   @doc """

--- a/lib/ohio_elixir/events/speaker.ex
+++ b/lib/ohio_elixir/events/speaker.ex
@@ -4,9 +4,8 @@ defmodule OhioElixir.Events.Speaker do
   import Ecto.Changeset
 
   schema "speakers" do
-    field :github_url, :string
     field :name, :string
-    field :twitter_url, :string
+    field :social_link, :string
 
     many_to_many :meetings, OhioElixir.Events.Meeting,
       join_through: "speakers_meetings",
@@ -18,7 +17,7 @@ defmodule OhioElixir.Events.Speaker do
   @doc false
   def changeset(speaker, attrs) do
     speaker
-    |> cast(attrs, [:name, :twitter_url, :github_url])
+    |> cast(attrs, [:name, :social_link])
     |> validate_required([:name])
   end
 end

--- a/lib/ohio_elixir_web/controllers/past_meetings_controller.ex
+++ b/lib/ohio_elixir_web/controllers/past_meetings_controller.ex
@@ -1,0 +1,10 @@
+defmodule OhioElixirWeb.PastMeetingsController do
+  use OhioElixirWeb, :controller
+
+  alias OhioElixir.Events
+
+  def index(conn, _params) do
+    meetings = Events.list_past_meetings() |> OhioElixir.Repo.preload(:speakers)
+    render(conn, "index.html", meetings: meetings)
+  end
+end

--- a/lib/ohio_elixir_web/router.ex
+++ b/lib/ohio_elixir_web/router.ex
@@ -20,6 +20,7 @@ defmodule OhioElixirWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :index
+    get "/past_meetings", PastMeetingsController, :index
   end
 
   # Other scopes may use custom stacks.

--- a/lib/ohio_elixir_web/templates/layout/app.html.eex
+++ b/lib/ohio_elixir_web/templates/layout/app.html.eex
@@ -27,6 +27,7 @@
             <li class="nav-item"><a href="https://github.com/Ohio-Elixir/ohio_elixir" class="nav-link" target="_blank">Github</a></li>
             <li class="nav-item"><a href="http://cbus-elixir-slackin.herokuapp.com/" class="nav-link" target="_blank">Slack</a></li>
             <li class="nav-item"><a href="https://twitter.com/ohioelixir" class="nav-link" target="_blank">Twitter</a></li>
+            <li class="nav-item"><%= link "Past Meetings", to: Routes.past_meetings_path(@conn, :index), class: "nav-link" %></li>
             <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
               <li class="nav-item"><%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home), class: "nav-link" %></li>
             <% end %>

--- a/lib/ohio_elixir_web/templates/page/_meetings.html.eex
+++ b/lib/ohio_elixir_web/templates/page/_meetings.html.eex
@@ -24,12 +24,10 @@
       <p><%= @meeting.title %></p>
       <%= for speaker <- @meeting.speakers do %>
         <p>
-          <%= speaker.name %>
-          <%= if speaker.twitter_url do %>
-            <%= link speaker.twitter_url, to: speaker.twitter_url %>
-          <% end %>
-          <%= if speaker.github_url do %>
-            <%= link speaker.github_url, to: speaker.github_url %>
+          <%= if speaker.social_link do %>
+            <%= link speaker.name, to: speaker.social_link, target: "_blank" %>
+          <% else %>
+            <%= speaker.name %>
           <% end %>
         </p>
       <% end %>

--- a/lib/ohio_elixir_web/templates/past_meetings/index.html.eex
+++ b/lib/ohio_elixir_web/templates/past_meetings/index.html.eex
@@ -1,0 +1,22 @@
+<div class="container">
+  <h1>Past Meetings</h1>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Title</th>
+        <th>Speakers<th>
+      </tr>
+    </thead>
+    <tbody>
+  <%= for meeting <- @meetings do %>
+      <tr>
+        <td><%= OhioElixirWeb.ViewHelpers.Date.format_date_time(meeting.date) %></td>
+        <td><%= meeting.title %></td>
+        <td><%= for speaker <- meeting.speakers, do: speaker_link(speaker) %></td>
+      </tr>
+  <% end %>
+    </tbody>
+  </table>
+</div>

--- a/lib/ohio_elixir_web/templates/speaker/form.html.eex
+++ b/lib/ohio_elixir_web/templates/speaker/form.html.eex
@@ -9,13 +9,9 @@
   <%= text_input f, :name %>
   <%= error_tag f, :name %>
 
-  <%= label f, :twitter_url %>
-  <%= text_input f, :twitter_url %>
-  <%= error_tag f, :twitter_url %>
-
-  <%= label f, :github_url %>
-  <%= text_input f, :github_url %>
-  <%= error_tag f, :github_url %>
+  <%= label f, :social_link %>
+  <%= text_input f, :social_link %>
+  <%= error_tag f, :social_link %>
 
   <div>
     <%= submit "Save" %>

--- a/lib/ohio_elixir_web/templates/speaker/index.html.eex
+++ b/lib/ohio_elixir_web/templates/speaker/index.html.eex
@@ -5,8 +5,7 @@
     <thead>
       <tr>
         <th>Name</th>
-        <th>Twitter url</th>
-        <th>Github url</th>
+        <th>Social Link</th>
 
         <th></th>
       </tr>
@@ -15,8 +14,7 @@
   <%= for speaker <- @speakers do %>
       <tr>
         <td><%= speaker.name %></td>
-        <td><%= speaker.twitter_url %></td>
-        <td><%= speaker.github_url %></td>
+        <td><%= speaker.social_link %></td>
 
         <td>
           <span><%= link "Show", to: Routes.speaker_path(@conn, :show, speaker) %></span> |

--- a/lib/ohio_elixir_web/templates/speaker/show.html.eex
+++ b/lib/ohio_elixir_web/templates/speaker/show.html.eex
@@ -9,13 +9,8 @@
     </li>
 
     <li>
-      <strong>Twitter url:</strong>
-      <%= @speaker.twitter_url %>
-    </li>
-
-    <li>
-      <strong>Github url:</strong>
-      <%= @speaker.github_url %>
+      <strong>Social Link:</strong>
+      <%= @speaker.social_link %>
     </li>
 
   </ul>

--- a/lib/ohio_elixir_web/views/past_meetings_view.ex
+++ b/lib/ohio_elixir_web/views/past_meetings_view.ex
@@ -1,0 +1,10 @@
+defmodule OhioElixirWeb.PastMeetingsView do
+  use OhioElixirWeb, :view
+
+  alias OhioElixir.Events.Speaker
+
+  def speaker_link(%Speaker{social_link: url} = speaker) when not is_nil(url),
+    do: raw('<a href="#{url}" target="_blank">#{speaker.name}</a><br>')
+
+  def speaker_link(speaker), do: raw('#{speaker.name}<br>')
+end

--- a/priv/repo/migrations/20210514022401_transition_to_speakers_social_link.exs
+++ b/priv/repo/migrations/20210514022401_transition_to_speakers_social_link.exs
@@ -1,0 +1,11 @@
+defmodule OhioElixir.Repo.Migrations.TransitionToSpeakersSocialLink do
+  use Ecto.Migration
+
+  def change do
+    alter table("speakers") do
+      remove :github_url
+      remove :twitter_url
+      add :social_link, :string
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -35,15 +35,13 @@ meeting_two =
 speaker_one =
   Repo.insert!(%Speaker{
     name: "Jane Doe",
-    github_url: "github.com/janedoe",
-    twitter_url: "twitter.com/janedoe"
+    social_link: "github.com/janedoe"
   })
 
 speaker_two =
   Repo.insert!(%Speaker{
     name: "John Doe",
-    github_url: "github.com/johndoe",
-    twitter_url: "twitter.com/johndoe"
+    social_link: "github.com/janedoe"
   })
 
 Events.add_speaker_to_meeting(meeting_one, speaker_one)

--- a/test/ohio_elixir/events_test.exs
+++ b/test/ohio_elixir/events_test.exs
@@ -16,6 +16,13 @@ defmodule OhioElixir.EventsTest do
       assert Events.list_meetings() == [meeting]
     end
 
+    test "list_past_meetings/0 only returns meetings from the past" do
+      _future_meeting = meeting_fixture(%{date: DateTime.add(DateTime.utc_now(), 3600)})
+      past_meeting_one = meeting_fixture(%{date: "2021-04-17T14:00:00Z"})
+      past_meeting_two = meeting_fixture(%{date: "2021-03-17T14:00:00Z"})
+      assert Events.list_past_meetings() == [past_meeting_one, past_meeting_two]
+    end
+
     test "get_meeting!/1 returns the meeting with given id" do
       meeting = meeting_fixture()
       assert Events.get_meeting!(meeting.id) == meeting
@@ -129,16 +136,14 @@ defmodule OhioElixir.EventsTest do
     alias OhioElixir.Events.Speaker
 
     @valid_attrs %{
-      github_url: "some github_url",
       name: "some name",
-      twitter_url: "some twitter_url"
+      social_link: "some twitter_url"
     }
     @update_attrs %{
-      github_url: "some updated github_url",
       name: "some updated name",
-      twitter_url: "some updated twitter_url"
+      social_link: "some updated twitter_url"
     }
-    @invalid_attrs %{github_url: nil, name: nil, twitter_url: nil}
+    @invalid_attrs %{name: nil, social_link: nil}
 
     test "list_speakers/0 returns all speakers" do
       speaker = speaker_fixture()
@@ -152,9 +157,8 @@ defmodule OhioElixir.EventsTest do
 
     test "create_speaker/1 with valid data creates a speaker" do
       assert {:ok, %Speaker{} = speaker} = Events.create_speaker(@valid_attrs)
-      assert speaker.github_url == "some github_url"
       assert speaker.name == "some name"
-      assert speaker.twitter_url == "some twitter_url"
+      assert speaker.social_link == "some twitter_url"
     end
 
     test "create_speaker/1 with invalid data returns error changeset" do
@@ -164,9 +168,8 @@ defmodule OhioElixir.EventsTest do
     test "update_speaker/2 with valid data updates the speaker" do
       speaker = speaker_fixture()
       assert {:ok, %Speaker{} = speaker} = Events.update_speaker(speaker, @update_attrs)
-      assert speaker.github_url == "some updated github_url"
       assert speaker.name == "some updated name"
-      assert speaker.twitter_url == "some updated twitter_url"
+      assert speaker.social_link == "some updated twitter_url"
     end
 
     test "update_speaker/2 with invalid data returns error changeset" do

--- a/test/ohio_elixir_web/controllers/past_meetings_controller_test.exs
+++ b/test/ohio_elixir_web/controllers/past_meetings_controller_test.exs
@@ -1,0 +1,10 @@
+defmodule OhioElixirWeb.PastMeetingsControllerTest do
+  use OhioElixirWeb.ConnCase
+
+  describe "index" do
+    test "lists past meetings", %{conn: conn} do
+      conn = get(conn, Routes.past_meetings_path(conn, :index))
+      assert html_response(conn, 200) =~ "Past Meetings"
+    end
+  end
+end

--- a/test/ohio_elixir_web/controllers/speaker_controller_test.exs
+++ b/test/ohio_elixir_web/controllers/speaker_controller_test.exs
@@ -3,16 +3,14 @@ defmodule OhioElixirWeb.SpeakerControllerTest do
   import OhioElixir.EventsFixture
 
   @create_attrs %{
-    github_url: "some github_url",
     name: "some name",
-    twitter_url: "some twitter_url"
+    social_link: "some twitter_url"
   }
   @update_attrs %{
-    github_url: "some updated github_url",
     name: "some updated name",
-    twitter_url: "some updated twitter_url"
+    social_link: "some updated twitter_url"
   }
-  @invalid_attrs %{github_url: nil, name: nil, twitter_url: nil}
+  @invalid_attrs %{name: nil, social_link: nil}
 
   setup :register_and_log_in_user
 
@@ -64,7 +62,7 @@ defmodule OhioElixirWeb.SpeakerControllerTest do
       assert redirected_to(conn) == Routes.speaker_path(conn, :show, speaker)
 
       conn = get(conn, Routes.speaker_path(conn, :show, speaker))
-      assert html_response(conn, 200) =~ "some updated github_url"
+      assert html_response(conn, 200) =~ "some updated twitter_url"
     end
 
     test "renders errors when data is invalid", %{conn: conn, speaker: speaker} do

--- a/test/ohio_elixir_web/views/past_meetings_view_test.exs
+++ b/test/ohio_elixir_web/views/past_meetings_view_test.exs
@@ -1,0 +1,23 @@
+defmodule OhioElixirWeb.PastMeetingsViewTest do
+  use OhioElixirWeb.ConnCase, async: true
+  import OhioElixir.EventsFixture
+
+  alias OhioElixirWeb.PastMeetingsView, as: View
+
+  setup [:create_speaker]
+
+  @tag social_link: "test_url"
+  test "links speaker name to social link when one is available", %{speaker: speaker} do
+    assert View.speaker_link(speaker) ==
+             {:safe, '<a href="test_url" target="_blank">some name</a><br>'}
+  end
+
+  @tag social_link: nil
+  test "returns speaker name if no social link is available", %{speaker: speaker} do
+    assert View.speaker_link(speaker) == {:safe, 'some name<br>'}
+  end
+
+  defp create_speaker(ctx) do
+    [speaker: speaker_fixture(%{social_link: ctx[:social_link]})]
+  end
+end

--- a/test/support/fixtures/events_fixture.ex
+++ b/test/support/fixtures/events_fixture.ex
@@ -10,9 +10,8 @@ defmodule OhioElixir.EventsFixture do
 
   def speaker_fixture(attrs \\ %{}) do
     valid_attrs = %{
-      github_url: "some github_url",
       name: "some name",
-      twitter_url: "some twitter_url"
+      social_link: "test_url"
     }
 
     {:ok, speaker} =


### PR DESCRIPTION
Create a basic "Past Meetings" page. This should allow users to see what type of meetings we've held in the past and who's talked.